### PR TITLE
modelYear bug

### DIFF
--- a/rentacar-angular/src/app/modules/admin/components/update-car/update-car.component.ts
+++ b/rentacar-angular/src/app/modules/admin/components/update-car/update-car.component.ts
@@ -66,7 +66,7 @@ export class UpdateCarComponent {
     formData.append('name', this.updateForm.get('name')?.value);
     formData.append('type', this.updateForm.get('type')?.value);
     formData.append('color', this.updateForm.get('color')?.value);
-    formData.append('modelYear', this.updateForm.get('year')?.value);
+    formData.append('modelYear', this.updateForm.get('modelYear')?.value);
     formData.append('transmission', this.updateForm.get('transmission')?.value);
     formData.append('description', this.updateForm.get('description')?.value);
     formData.append('price', this.updateForm.get('price')?.value);


### PR DESCRIPTION
When I was updating the car from admin side, the model year was not getting updated because the formControl value is modelYear and the value which I was getting from the form to update was year. I changed this year to modelYear and now it's working fine.